### PR TITLE
Expect yarn to be a global npm package install

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -27,6 +27,11 @@ if [ -f "Gemfile" ]; then
 fi
 
 if [ -f "package.json" ]; then
+  if ! command -v yarn >/dev/null; then
+    echo "==> Installing yarn…"
+    npm install -g yarn
+  fi
+
   echo "==> Installing node packages…"
   yarn
 fi

--- a/support/Brewfile
+++ b/support/Brewfile
@@ -1,4 +1,3 @@
 tap "cultureamp/web-team-devtools"
 brew "asdf"
 brew "overmind"
-brew "yarn"


### PR DESCRIPTION
We’ll no longer install it via Homebrew, meaning we shouldn’t clobber people’s existing installs, particularly if they installed it via other means.

Plus, an npm-based install appears to be more consistent with yarn installation recommendations these days.

See https://github.com/cultureamp/web-team-dotfiles/pull/1 for a related change in our dot files, which will install yarn automatically for any new node version.